### PR TITLE
Check for greyscale when small image uses palette

### DIFF
--- a/src/zopfli/blocksplitter.c
+++ b/src/zopfli/blocksplitter.c
@@ -280,6 +280,7 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
                       size_t maxblocks, size_t** splitpoints, size_t* npoints, SymbolStats** stats) {
   size_t pos = 0;
   size_t i;
+  size_t shift;
   ZopfliBlockState s;
   size_t* lz77splitpoints = 0;
   size_t nlz77points = 0;
@@ -325,7 +326,7 @@ void ZopfliBlockSplit(const ZopfliOptions* options,
       }
       pos += length;
     }
-    size_t shift = lz77splitpoints[*npoints - 1];
+    shift = lz77splitpoints[*npoints - 1];
     store.size -= shift;
     store.dists += shift;
     store.litlens += shift;

--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -239,7 +239,7 @@ unsigned TryOptimize(
       // Too small for tRNS chunk overhead.
       if (w * h <= 16 && profile.key) profile.alpha = 1;
       state.encoder.auto_convert = 0;
-      state.info_png.color.colortype = (profile.alpha ? LCT_RGBA : LCT_RGB);
+      state.info_png.color.colortype = (profile.alpha ? (profile.colored ? LCT_RGBA : LCT_GREY_ALPHA) : (profile.colored ? LCT_RGB : LCT_GREY));
       state.info_png.color.bitdepth = 8;
       state.info_png.color.key_defined = (profile.key && !profile.alpha);
       if (state.info_png.color.key_defined) {

--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -221,8 +221,10 @@ unsigned TryOptimize(
       break;
   }
 
+#ifdef LODEPNG_COMPILE_ANCILLARY_CHUNKS
   state.encoder.add_id = false;
   state.encoder.text_compression = 1;
+#endif /*LODEPNG_COMPILE_ANCILLARY_CHUNKS*/
 
   error = lodepng::encode(*out, image, w, h, state);
 


### PR DESCRIPTION
When a small file is stored with a palette, a test is made to see if
removing the palette, and the overhead that goes with it, results in
an even smaller file.  That test was always attempting RGB or RGBA
mode even when the image in question was greyscale.  I added a check
for greyscale.