### PR TITLE
Check for greyscale when small image uses palette

### DIFF
--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -239,7 +239,7 @@ unsigned TryOptimize(
       // Too small for tRNS chunk overhead.
       if (w * h <= 16 && profile.key) profile.alpha = 1;
       state.encoder.auto_convert = 0;
-      state.info_png.color.colortype = (profile.alpha ? LCT_RGBA : LCT_RGB);
+      state.info_png.color.colortype = (profile.alpha ? (profile.colored ? LCT_RGBA : LCT_GREY_ALPHA) : (profile.colored ? LCT_RGB : LCT_GREY));
       state.info_png.color.bitdepth = 8;
       state.info_png.color.key_defined = (profile.key && !profile.alpha);
       if (state.info_png.color.key_defined) {

--- a/src/zopflipng/zopflipng_lib.cc
+++ b/src/zopflipng/zopflipng_lib.cc
@@ -240,7 +240,7 @@ unsigned TryOptimize(
       if (w * h <= 16 && profile.key) profile.alpha = 1;
       state.encoder.auto_convert = 0;
       state.info_png.color.colortype = (profile.alpha ? (profile.colored ? LCT_RGBA : LCT_GREY_ALPHA) : (profile.colored ? LCT_RGB : LCT_GREY));
-      state.info_png.color.bitdepth = 8;
+      state.info_png.color.bitdepth = (profile.alpha || profile.colored) ? 8 : profile.bits;
       state.info_png.color.key_defined = (profile.key && !profile.alpha);
       if (state.info_png.color.key_defined) {
         state.info_png.color.key_defined = 1;


### PR DESCRIPTION
When a small file is stored with a palette, a test is made to see if
removing the palette, and the overhead that goes with it, results in
an even smaller file.  That test was always attempting RGB or RGBA
mode even when the image in question was greyscale.  I added a check
for greyscale.